### PR TITLE
enhancement: add more logs

### DIFF
--- a/pkg/internal/app/grpc.go
+++ b/pkg/internal/app/grpc.go
@@ -53,7 +53,7 @@ func (app *demoApp) OpenInApp(
 
 	// required for the response, it will be used also for logs
 	providerFileRef := providerv1beta1.Reference{
-		ResourceId: req.GetResourceInfo().Id,
+		ResourceId: req.GetResourceInfo().GetId(),
 		Path:       ".",
 	}
 

--- a/pkg/internal/app/grpc.go
+++ b/pkg/internal/app/grpc.go
@@ -114,8 +114,7 @@ func (app *demoApp) OpenInApp(
 			Err(err).
 			Str("FileReference", providerFileRef.String()).
 			Str("ViewMode", req.ViewMode.String()).
-			Str("Requester", user.GetUsername()).
-			Str("RequesterDisplayName", user.GetDisplayName()).
+			Str("Requester", user.GetId().String()).
 			Msg("OpenInApp: error parsing viewAppUrl")
 		return nil, err
 	}
@@ -125,8 +124,7 @@ func (app *demoApp) OpenInApp(
 			Err(err).
 			Str("FileReference", providerFileRef.String()).
 			Str("ViewMode", req.ViewMode.String()).
-			Str("Requester", user.GetUsername()).
-			Str("RequesterDisplayName", user.GetDisplayName()).
+			Str("Requester", user.GetId().String()).
 			Msg("OpenInApp: error parsing editAppUrl")
 		return nil, err
 	}
@@ -142,8 +140,7 @@ func (app *demoApp) OpenInApp(
 			Err(err).
 			Str("FileReference", providerFileRef.String()).
 			Str("ViewMode", req.ViewMode.String()).
-			Str("Requester", user.GetUsername()).
-			Str("RequesterDisplayName", user.GetDisplayName()).
+			Str("Requester", user.GetId().String()).
 			Msg("OpenInApp: error encrypting access token")
 		return &appproviderv1beta1.OpenInAppResponse{
 			Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_INTERNAL},
@@ -167,8 +164,7 @@ func (app *demoApp) OpenInApp(
 			Err(err).
 			Str("FileReference", providerFileRef.String()).
 			Str("ViewMode", req.ViewMode.String()).
-			Str("Requester", user.GetUsername()).
-			Str("RequesterDisplayName", user.GetDisplayName()).
+			Str("Requester", user.GetId().String()).
 			Msg("OpenInApp: error parsing JWT token")
 		return nil, err
 	}
@@ -188,8 +184,7 @@ func (app *demoApp) OpenInApp(
 			Err(err).
 			Str("FileReference", providerFileRef.String()).
 			Str("ViewMode", req.ViewMode.String()).
-			Str("Requester", user.GetUsername()).
-			Str("RequesterDisplayName", user.GetDisplayName()).
+			Str("Requester", user.GetId().String()).
 			Msg("OpenInApp: error signing access token")
 		return &appproviderv1beta1.OpenInAppResponse{
 			Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_INTERNAL},
@@ -199,8 +194,7 @@ func (app *demoApp) OpenInApp(
 	app.Logger.Debug().
 		Str("FileReference", providerFileRef.String()).
 		Str("ViewMode", req.ViewMode.String()).
-		Str("Requester", user.GetUsername()).
-		Str("RequesterDisplayName", user.GetDisplayName()).
+		Str("Requester", user.GetId().String()).
 		Msg("OpenInApp: success")
 
 	return &appproviderv1beta1.OpenInAppResponse{

--- a/pkg/internal/app/wopidiscovery.go
+++ b/pkg/internal/app/wopidiscovery.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/beevik/etree"
@@ -50,7 +49,7 @@ func getAppURLs(wopiAppUrl string, insecure bool, logger log.Logger) (map[string
 		logger.Error().
 			Str("WopiAppUrl", wopiAppUrl).
 			Int("HttpCode", httpResp.StatusCode).
-			Msg("WopiDiscovery: wopi app url failed with code " + strconv.Itoa(httpResp.StatusCode))
+			Msg("WopiDiscovery: wopi app url failed with unexpected code")
 		return nil, errors.New("status code was not 200")
 	}
 

--- a/pkg/internal/app/wopifilecontents.go
+++ b/pkg/internal/app/wopifilecontents.go
@@ -24,7 +24,14 @@ func GetFile(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err != nil || resp.StatusCode != http.StatusOK {
-		app.Logger.Error().Err(err).Str("status_code", http.StatusText(resp.StatusCode)).Str("FileReference", wopiContext.FileReference.String()).Msg("GetFile: downloading the file failed")
+		app.Logger.Error().
+			Err(err).
+			Str("FileReference", wopiContext.FileReference.String()).
+			Str("ViewMode", wopiContext.ViewMode.String()).
+			Str("Requester", wopiContext.User.GetUsername()).
+			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Int("HttpCode", resp.StatusCode).
+			Msg("GetFile: downloading the file failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -33,11 +40,22 @@ func GetFile(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 	_, err = io.Copy(w, resp.Body)
 	if err != nil {
-		app.Logger.Error().Str("FileReference", wopiContext.FileReference.String()).Msg("GetFile: copying the file content to the response body failed")
+		app.Logger.Error().
+			Str("FileReference", wopiContext.FileReference.String()).
+			Str("ViewMode", wopiContext.ViewMode.String()).
+			Str("Requester", wopiContext.User.GetUsername()).
+			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Msg("GetFile: copying the file content to the response body failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
+	app.Logger.Debug().
+		Str("FileReference", wopiContext.FileReference.String()).
+		Str("ViewMode", wopiContext.ViewMode.String()).
+		Str("Requester", wopiContext.User.GetUsername()).
+		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		Msg("GetFile: success")
 	http.Error(w, "", http.StatusOK)
 }
 
@@ -63,10 +81,22 @@ func PutFile(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err != nil {
-		app.Logger.Error().Err(err).Str("FileReference", wopiContext.FileReference.String()).Msg("PutFile: uploading the file failed")
+		app.Logger.Error().
+			Err(err).
+			Str("FileReference", wopiContext.FileReference.String()).
+			Str("ViewMode", wopiContext.ViewMode.String()).
+			Str("Requester", wopiContext.User.GetUsername()).
+			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Msg("PutFile: uploading the file failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
+	app.Logger.Debug().
+		Str("FileReference", wopiContext.FileReference.String()).
+		Str("ViewMode", wopiContext.ViewMode.String()).
+		Str("Requester", wopiContext.User.GetUsername()).
+		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		Msg("PutFile: success")
 	http.Error(w, "", http.StatusOK)
 }

--- a/pkg/internal/app/wopifilecontents.go
+++ b/pkg/internal/app/wopifilecontents.go
@@ -28,8 +28,7 @@ func GetFile(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Err(err).
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Int("HttpCode", resp.StatusCode).
 			Msg("GetFile: downloading the file failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -43,8 +42,7 @@ func GetFile(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Error().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Msg("GetFile: copying the file content to the response body failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -53,8 +51,7 @@ func GetFile(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	app.Logger.Debug().
 		Str("FileReference", wopiContext.FileReference.String()).
 		Str("ViewMode", wopiContext.ViewMode.String()).
-		Str("Requester", wopiContext.User.GetUsername()).
-		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		Str("Requester", wopiContext.User.GetId().String()).
 		Msg("GetFile: success")
 	http.Error(w, "", http.StatusOK)
 }
@@ -85,8 +82,7 @@ func PutFile(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Err(err).
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Msg("PutFile: uploading the file failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -95,8 +91,7 @@ func PutFile(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	app.Logger.Debug().
 		Str("FileReference", wopiContext.FileReference.String()).
 		Str("ViewMode", wopiContext.ViewMode.String()).
-		Str("Requester", wopiContext.User.GetUsername()).
-		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		Str("Requester", wopiContext.User.GetId().String()).
 		Msg("PutFile: success")
 	http.Error(w, "", http.StatusOK)
 }

--- a/pkg/internal/app/wopiinfo.go
+++ b/pkg/internal/app/wopiinfo.go
@@ -45,7 +45,7 @@ func CheckFileInfo(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Str("Requester", wopiContext.User.GetId().String()).
 			Str("StatusCode", statRes.Status.Code.String()).
 			Str("StatusMsg", statRes.Status.Message).
-			Msg("CheckFileInfo: stat failed with status " + statRes.Status.Code.String())
+			Msg("CheckFileInfo: stat failed with unexpected status")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -128,7 +128,6 @@ func CheckFileInfo(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		Str("FileReference", wopiContext.FileReference.String()).
 		Str("ViewMode", wopiContext.ViewMode.String()).
 		Str("Requester", wopiContext.User.GetId().String()).
-		RawJSON("Fileinfo", jsonFileInfo).
 		Msg("CheckFileInfo: success")
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/internal/app/wopiinfo.go
+++ b/pkg/internal/app/wopiinfo.go
@@ -13,6 +13,8 @@ import (
 )
 
 func WopiInfoHandler(app *demoApp, w http.ResponseWriter, r *http.Request) {
+	// Logs for this endpoint will be covered by the access log. We can't extract
+	// more info
 	http.Error(w, http.StatusText(http.StatusTeapot), http.StatusTeapot)
 }
 
@@ -26,13 +28,26 @@ func CheckFileInfo(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		Ref: &wopiContext.FileReference,
 	})
 	if err != nil {
-		app.Logger.Error().Err(err).Str("FileReference", wopiContext.FileReference.String()).Msg("CheckFileInfo: stat failed")
+		app.Logger.Error().
+			Err(err).
+			Str("FileReference", wopiContext.FileReference.String()).
+			Str("ViewMode", wopiContext.ViewMode.String()).
+			Str("Requester", wopiContext.User.GetUsername()).
+			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Msg("CheckFileInfo: stat failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
 	if statRes.Status.Code != rpcv1beta1.Code_CODE_OK {
-		app.Logger.Error().Str("status_code", statRes.Status.Code.String()).Str("FileReference", wopiContext.FileReference.String()).Msg("CheckFileInfo: stat failed")
+		app.Logger.Error().
+			Str("FileReference", wopiContext.FileReference.String()).
+			Str("ViewMode", wopiContext.ViewMode.String()).
+			Str("Requester", wopiContext.User.GetUsername()).
+			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("StatusCode", statRes.Status.Code.String()).
+			Str("StatusMsg", statRes.Status.Message).
+			Msg("CheckFileInfo: stat failed with status " + statRes.Status.Code.String())
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -101,9 +116,24 @@ func CheckFileInfo(app *demoApp, w http.ResponseWriter, r *http.Request) {
 
 	jsonFileInfo, err := json.Marshal(fileInfo)
 	if err != nil {
+		app.Logger.Error().
+			Err(err).
+			Str("FileReference", wopiContext.FileReference.String()).
+			Str("ViewMode", wopiContext.ViewMode.String()).
+			Str("Requester", wopiContext.User.GetUsername()).
+			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Msg("CheckFileInfo: failed to marshal fileinfo")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+
+	app.Logger.Debug().
+		Str("FileReference", wopiContext.FileReference.String()).
+		Str("ViewMode", wopiContext.ViewMode.String()).
+		Str("Requester", wopiContext.User.GetUsername()).
+		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		RawJSON("Fileinfo", jsonFileInfo).
+		Msg("CheckFileInfo: success")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(jsonFileInfo)

--- a/pkg/internal/app/wopiinfo.go
+++ b/pkg/internal/app/wopiinfo.go
@@ -32,8 +32,7 @@ func CheckFileInfo(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Err(err).
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Msg("CheckFileInfo: stat failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -43,8 +42,7 @@ func CheckFileInfo(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Error().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Str("StatusCode", statRes.Status.Code.String()).
 			Str("StatusMsg", statRes.Status.Message).
 			Msg("CheckFileInfo: stat failed with status " + statRes.Status.Code.String())
@@ -120,8 +118,7 @@ func CheckFileInfo(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Err(err).
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Msg("CheckFileInfo: failed to marshal fileinfo")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -130,8 +127,7 @@ func CheckFileInfo(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	app.Logger.Debug().
 		Str("FileReference", wopiContext.FileReference.String()).
 		Str("ViewMode", wopiContext.ViewMode.String()).
-		Str("Requester", wopiContext.User.GetUsername()).
-		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		Str("Requester", wopiContext.User.GetId().String()).
 		RawJSON("Fileinfo", jsonFileInfo).
 		Msg("CheckFileInfo: success")
 

--- a/pkg/internal/app/wopilocking.go
+++ b/pkg/internal/app/wopilocking.go
@@ -31,8 +31,7 @@ func GetLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Err(err).
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Msg("GetLock failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -42,8 +41,7 @@ func GetLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Error().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Str("StatusCode", resp.Status.Code.String()).
 			Str("StatusMsg", resp.Status.Message).
 			Msg("GetLock failed with status " + resp.Status.Code.String())
@@ -60,8 +58,7 @@ func GetLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	app.Logger.Debug().
 		Str("FileReference", wopiContext.FileReference.String()).
 		Str("ViewMode", wopiContext.ViewMode.String()).
-		Str("Requester", wopiContext.User.GetUsername()).
-		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		Str("Requester", wopiContext.User.GetId().String()).
 		Str("StatusCode", resp.Status.Code.String()).
 		Str("LockID", lockID).
 		Msg("GetLock success")
@@ -84,8 +81,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Error().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Msg("Lock failed due to empty lockID")
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
@@ -106,8 +102,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	app.Logger.Debug().
 		Str("FileReference", wopiContext.FileReference.String()).
 		Str("ViewMode", wopiContext.ViewMode.String()).
-		Str("Requester", wopiContext.User.GetUsername()).
-		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		Str("Requester", wopiContext.User.GetId().String()).
 		Str("RequestedLockID", lockID).
 		Msg("Performing SetLock")
 
@@ -117,8 +112,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Err(err).
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Str("RequestedLockID", lockID).
 			Msg("SetLock failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -130,8 +124,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Debug().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Str("RequestedLockID", lockID).
 			Msg("SetLock successful")
 		http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)
@@ -149,8 +142,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 				Err(err).
 				Str("FileReference", wopiContext.FileReference.String()).
 				Str("ViewMode", wopiContext.ViewMode.String()).
-				Str("Requester", wopiContext.User.GetUsername()).
-				Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+				Str("Requester", wopiContext.User.GetId().String()).
 				Str("RequestedLockID", lockID).
 				Msg("SetLock failed, fallback to GetLock failed too")
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -161,8 +153,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			app.Logger.Error().
 				Str("FileReference", wopiContext.FileReference.String()).
 				Str("ViewMode", wopiContext.ViewMode.String()).
-				Str("Requester", wopiContext.User.GetUsername()).
-				Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+				Str("Requester", wopiContext.User.GetId().String()).
 				Str("RequestedLockID", lockID).
 				Str("StatusCode", resp.Status.Code.String()).
 				Str("StatusMsg", resp.Status.Message).
@@ -175,8 +166,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 				app.Logger.Warn().
 					Str("FileReference", wopiContext.FileReference.String()).
 					Str("ViewMode", wopiContext.ViewMode.String()).
-					Str("Requester", wopiContext.User.GetUsername()).
-					Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+					Str("Requester", wopiContext.User.GetId().String()).
 					Str("RequestedLockID", lockID).
 					Str("LockID", resp.Lock.LockId).
 					Msg("SetLock conflict")
@@ -190,8 +180,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			app.Logger.Warn().
 				Str("FileReference", wopiContext.FileReference.String()).
 				Str("ViewMode", wopiContext.ViewMode.String()).
-				Str("Requester", wopiContext.User.GetUsername()).
-				Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+				Str("Requester", wopiContext.User.GetId().String()).
 				Str("RequestedLockID", lockID).
 				Str("LockID", resp.Lock.LockId).
 				Msg("SetLock lock refreshed instead")
@@ -202,8 +191,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Error().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Str("RequestedLockID", lockID).
 			Msg("SetLock failed and could not refresh")
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -213,8 +201,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Error().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Str("RequestedLockID", lockID).
 			Str("StatusCode", resp.Status.Code.String()).
 			Str("StatusMsg", resp.Status.Message).
@@ -243,8 +230,7 @@ func UnLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Error().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Msg("Unlock failed due to empty lockID")
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
@@ -264,8 +250,7 @@ func UnLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Err(err).
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Str("RequestedLockID", lockID).
 			Msg("Unlock failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -276,8 +261,7 @@ func UnLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 		app.Logger.Error().
 			Str("FileReference", wopiContext.FileReference.String()).
 			Str("ViewMode", wopiContext.ViewMode.String()).
-			Str("Requester", wopiContext.User.GetUsername()).
-			Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+			Str("Requester", wopiContext.User.GetId().String()).
 			Str("RequestedLockID", lockID).
 			Str("StatusCode", resp.Status.Code.String()).
 			Str("StatusMsg", resp.Status.Message).
@@ -289,8 +273,7 @@ func UnLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 	app.Logger.Debug().
 		Str("FileReference", wopiContext.FileReference.String()).
 		Str("ViewMode", wopiContext.ViewMode.String()).
-		Str("Requester", wopiContext.User.GetUsername()).
-		Str("RequesterDisplayName", wopiContext.User.GetDisplayName()).
+		Str("Requester", wopiContext.User.GetId().String()).
 		Str("RequestedLockID", lockID).
 		Msg("Unlock successful")
 	http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)

--- a/pkg/internal/app/wopilocking.go
+++ b/pkg/internal/app/wopilocking.go
@@ -44,7 +44,7 @@ func GetLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Str("Requester", wopiContext.User.GetId().String()).
 			Str("StatusCode", resp.Status.Code.String()).
 			Str("StatusMsg", resp.Status.Message).
-			Msg("GetLock failed with status " + resp.Status.Code.String())
+			Msg("GetLock failed with unexpected status")
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
 	}
@@ -157,7 +157,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 				Str("RequestedLockID", lockID).
 				Str("StatusCode", resp.Status.Code.String()).
 				Str("StatusMsg", resp.Status.Message).
-				Msg("SetLock failed, fallback to GetLock failed with status " + resp.Status.Code.String())
+				Msg("SetLock failed, fallback to GetLock failed with unexpected status")
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
 
@@ -205,7 +205,7 @@ func Lock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Str("RequestedLockID", lockID).
 			Str("StatusCode", resp.Status.Code.String()).
 			Str("StatusMsg", resp.Status.Message).
-			Msg("SetLock failed with status " + resp.Status.Code.String())
+			Msg("SetLock failed with unexpected status")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -265,7 +265,7 @@ func UnLock(app *demoApp, w http.ResponseWriter, r *http.Request) {
 			Str("RequestedLockID", lockID).
 			Str("StatusCode", resp.Status.Code.String()).
 			Str("StatusMsg", resp.Status.Message).
-			Msg("Unlock failed with status code " + resp.Status.Code.String())
+			Msg("Unlock failed with unexpected status")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/internal/helpers/upload.go
+++ b/pkg/internal/helpers/upload.go
@@ -119,7 +119,7 @@ func UploadFile(ctx context.Context, content io.ReadCloser, ref *providerv1beta1
 			Str("Endpoint", uploadEndpoint).
 			Bool("HasUploadToken", hasUploadToken).
 			Int("HttpCode", httpResp.StatusCode).
-			Msg("UploadHelper: Put request to the upload endpoint failed")
+			Msg("UploadHelper: Put request to the upload endpoint failed with unexpected status")
 		return errors.New("Put request failed with status " + strconv.Itoa(httpResp.StatusCode))
 	}
 


### PR DESCRIPTION
Most of the new logs are for the wopi operations.
* They'll use the file reference, view mode, requester's username and display name
  * Status code and message if available (for grpc or http calls).
  * The requested lock id (for lock operation)
* Messages are unique for easier debugging in order to know where the error happened in the code
* All operations have a debug level "success" log to track the operation if needed.

There are a few exceptions:
* Lock conflicts will log a warning
* Refreshing the lock via a "setLock" operation instead of the actual "refreshLock" (not implemented now) will log a warning. Technically this is fine because the wopi server is performing a different operation than requested although the result is the same.
* There are some additional logs for the wopi discovery phase during startup, but those logs are only for errors. As commented in the code, the only useful information would be the urls of the apps, but it's tricky to log them, and log only a "all is good" message is pointless there.

Other than logs, there are small touches for readability, but the behavior of the wopi server remains unchanged.

**NOTE**: The debug log for the getFileInfo operation will log the fileinfo of the file. Need to decide what to do with that as it might leak important info, but at the same time it could contain info useful for debugging.