### PR TITLE
feat: include a simple healthcheck endpoint for the WOPI server

### DIFF
--- a/pkg/cs3wopiserver/start.go
+++ b/pkg/cs3wopiserver/start.go
@@ -2,10 +2,11 @@ package cs3wopiserver
 
 import (
 	"context"
-	"github.com/owncloud/cs3-wopi-server/pkg/internal/app"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/owncloud/cs3-wopi-server/pkg/internal/app"
 )
 
 func Start() error {
@@ -36,6 +37,8 @@ func Start() error {
 		return err
 	}
 
+	// Setting up the HTTP server should be the last step because
+	// there is a healthcheck set inside.
 	if err := app.HTTPServer(ctx); err != nil {
 		return err
 	}

--- a/pkg/internal/app/http.go
+++ b/pkg/internal/app/http.go
@@ -15,6 +15,10 @@ func (app *demoApp) HTTPServer(ctx context.Context) error {
 
 	r.Use(middleware.AccessLog(app.Logger))
 
+	r.Get("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)
+	})
+
 	r.Route("/wopi", func(r chi.Router) {
 
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Include a simple health check for the service in order to know when the WOPI server has finished with the startup process.

Note that the WOPI server depends on some ocis services as well as the document server (onlyoffice, collabora and others). Onlyoffice takes some seconds to start, and the WOPI server should wait for it. As a consequence, any service depending on the WOPI server might take some time to be ready.
The healthcheck will help other services to know when the WOPI server is ready

For docker-compose, the recommended setup for the wopiserver might include:
```
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:6789/healthcheck"]
      interval: 5m
      timeout: 10s
      retries: 3
      start_period: 15s
      start_interval: 5s
```
Note that `curl` needs to be installed in the docker image, and the server will start in the 6789 port.

Relevant configuration for the docker-compose file (note that ocis doesn't have a healthcheck currently):
```
  wopiserver-onlyoffice:
    depends_on:
      ocis:
        condition: service_started
      onlyoffice:
        condition: service_healthy
    environment:
      MICRO_REGISTRY: "mdns"

      WOPI_GRPC_BIND_ADDR: 0.0.0.0:5678
      WOPI_HTTP_BIND_ADDR: 0.0.0.0:6789

    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:6789/healthcheck"]
      interval: 5m
      timeout: 10s
      retries: 3
      start_period: 15s
      start_interval: 5s

  onlyoffice:
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost/healthcheck"]
      interval: 5m
      timeout: 10s
      retries: 3
      start_period: 1m
      start_interval: 5s

```

For now, the intention of the healthcheck is to provide a simple way for the orchestrators (docker-compose, kubernetes, etc) to know when the WOPI server has fully started. Extensive checks, such as checking the connectivity with dependent services, aren't planned.